### PR TITLE
feat: integrate Metaso MCP for WeChat links

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -2,6 +2,7 @@ import { handleSinglePhoto } from '../handlers/handleSinglePhoto.js';
 import { handleMediaGroupPhoto } from '../handlers/handleMediaGroupPhoto.js';
 import { handleFlomo } from '../handlers/handleFlomo.js';
 import { handleNotion } from '../handlers/handleNotion.js';
+import { handleWechatLink } from '../handlers/link-wechat.js';
 import { Bot, session } from 'grammy';
 import type { MyContext, SessionData } from '../utils/types.js';
 import dotenv from 'dotenv';
@@ -32,6 +33,10 @@ bot.on('message:photo', async (ctx) => {
     } else {
         await handleSinglePhoto(ctx);
     }
+});
+
+bot.on('message:text', async (ctx) => {
+    await handleWechatLink(ctx);
 });
 
 

--- a/src/handlers/link-wechat.ts
+++ b/src/handlers/link-wechat.ts
@@ -1,0 +1,36 @@
+import { type MyContext } from '../utils/types.js';
+import { fetchWechatMarkdown } from '../utils/metaso.js';
+import { handlePolish } from './handlePolish.js';
+import { safeReply } from '../utils/safeReply.js';
+import { logger } from '../utils/logger.js';
+
+const WECHAT_REG = /https?:\/\/mp\.weixin\.qq\.com\/\S+/i;
+
+export function extractWechatLink(text?: string): string | null {
+  if (!text) return null;
+  const match = text.match(WECHAT_REG);
+  return match ? match[0] : null;
+}
+
+export async function handleWechatLink(ctx: MyContext) {
+  const link = extractWechatLink(ctx.message?.text);
+  if (!link) return;
+
+  logger.info('处理微信链接', link);
+  const markdown = await fetchWechatMarkdown(link);
+  const polished = await handlePolish(markdown);
+
+  ctx.session.lastPolishedText = polished;
+
+  await safeReply(ctx, `✨ 澎色完成内容：\n\n${polished}`, { parse_mode: 'Markdown' });
+  await ctx.reply('是否保存到 Flomo？', {
+    reply_markup: {
+      inline_keyboard: [
+        [
+          { text: '✅ 保存到 Flomo', callback_data: 'save_flomo' },
+          { text: '📘 Notion', callback_data: 'save_notion' }
+        ]
+      ]
+    }
+  });
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,5 @@
+export const logger = {
+  info: (...args: unknown[]) => console.log('[INFO]', ...args),
+  warn: (...args: unknown[]) => console.warn('[WARN]', ...args),
+  error: (...args: unknown[]) => console.error('[ERROR]', ...args),
+};

--- a/src/utils/mcp-client.ts
+++ b/src/utils/mcp-client.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+export interface McpOptions {
+  endpoint: string;
+  apiKey?: string;
+}
+
+export async function callMcp<T = any>(opts: McpOptions, payload: any): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (opts.apiKey) {
+    headers['Authorization'] = `Bearer ${opts.apiKey}`;
+  }
+
+  const resp = await axios.post(opts.endpoint, payload, { headers });
+  return resp.data as T;
+}

--- a/src/utils/metaso.ts
+++ b/src/utils/metaso.ts
@@ -1,0 +1,21 @@
+import { callMcp } from './mcp-client.js';
+import { logger } from './logger.js';
+
+const METASO_ENDPOINT = process.env.METASO_MCP_URL!;
+const METASO_API_KEY = process.env.METASO_API_KEY;
+
+export async function fetchWechatMarkdown(link: string): Promise<string> {
+  try {
+    const options = METASO_API_KEY
+      ? { endpoint: METASO_ENDPOINT, apiKey: METASO_API_KEY }
+      : { endpoint: METASO_ENDPOINT };
+    const data = await callMcp<{ markdown?: string; content?: string; }>(
+      options,
+      { url: link, format: 'markdown' }
+    );
+    return data.markdown || data.content || '';
+  } catch (err) {
+    logger.error('metaso 调用失败', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add generic MCP client and Metaso wrapper
- support processing WeChat links by fetching markdown and polishing via DeepSeek
- add simple logger utility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7572d30a0832eba5316a30d52ddfb